### PR TITLE
adding confidence base functionality to createGeoJSONFromRaster

### DIFF
--- a/spacenetutilities/labeltools/coreLabelTools.py
+++ b/spacenetutilities/labeltools/coreLabelTools.py
@@ -134,7 +134,8 @@ def createGeoJSONFromRaster(geoJsonFileName,
                             transformAffineObject,
                             crs,
                             maskValue=0,
-                            fieldName="rasterVal"):
+                            fieldName="rasterVal",
+                            conf=None):
 
     featureGenerator = polygonize(imageArray,
                                   transformAffineObject,
@@ -143,6 +144,8 @@ def createGeoJSONFromRaster(geoJsonFileName,
     featureGDF = createGDFfromShapes(featureGenerator,
                                      fieldName=fieldName)
     featureGDF.crs = crs
+    if conf is None:
+        featureGDF['conf'] = 1
 
     gT.exporttogeojson(geoJsonFileName, featureGDF)
 


### PR DESCRIPTION
Adding a `conf=None` default argument to `createGeoJSONFromRaster()`. The `createGeoJSONFromRaster` function now adds a `conf` column to the `featureGDF` that it outputs. This is currently set to 1 when `conf=None` with no alternative methods to calculate it within this function. `conf` argument - the plan will be to enable future confidence estimation in `polygonize` (by adding additional arguments there as well). This enables use of `createGeoJSONFromRaster()` with [cw-eval](https://github.com/CosmiQ/cw-eval)'s `eval_base()`.

This has been tested on one specific case and found to work.